### PR TITLE
Added more options to the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,10 @@ to either: `all | consumer | publisher | none`.
 
 The default value is `none`
 
+You can also use the `extraOptions.loggerInstance` to pass your custom Logger
+as long as it follows the Logger/Console interfaces. The SDK will use the given
+instance to log any messages
+
 ### Detach connection from NestJS lifecycle
 
 By passing the flag `extraOptions.connectionType = 'async'` the library will not

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ createRabbitOptions(): RabbitMQModuleOptions {
 The consumer **DOES NOT** create exchanges and only bind to ones that already
 exists. This is to avoid creating exchanges with typos and misconfigurations.
 
+You can also declare an array of `routingKeys: string[]` if you want to attach multiple keys to the same queue/callback
+
 ### The messageHandler callback
 
 As declared in the example above, the `messageHandler` property expects a

--- a/README.md
+++ b/README.md
@@ -229,9 +229,11 @@ createRabbitOptions(): RabbitMQModuleOptions {
 ```
 
 The consumer **DOES NOT** create exchanges and only bind to ones that already
-exists. This is to avoid creating exchanges with typos and misconfigurations.
+exists. This is to avoid creating exchanges with typos and
+misconfigurations.
 
-You can also declare an array of `routingKeys: string[]` if you want to attach multiple keys to the same queue/callback
+You can also declare an array of `routingKeys: string[]` if you want to attach
+multiple keys to the same queue/callback
 
 ### The messageHandler callback
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bgaldino/nestjs-rabbitmq",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A different way of configuring your RabbitMQ",
   "main": "dist/index.js",
   "author": "Bruno Galdino <brunogaldinoc@gmail.com>",

--- a/src/amqp-connection-manager.ts
+++ b/src/amqp-connection-manager.ts
@@ -21,7 +21,8 @@ import { RabbitOptionsFactory } from "./rabbitmq.interfaces";
 export class AMQPConnectionManager
   implements OnModuleInit, OnApplicationBootstrap, OnApplicationShutdown
 {
-  private readonly logger: Logger = new Logger(AMQPConnectionManager.name);
+  // private readonly logger: Logger = new Logger(AMQPConnectionManager.name);
+  private readonly logger: Console | Logger;
   private rabbitTerminalErrors: string[] = [
     "channel-error",
     "precondition-failed",
@@ -45,6 +46,9 @@ export class AMQPConnectionManager
   private connectionBlockedReason: string;
 
   constructor(@Inject("RABBIT_OPTIONS") options: RabbitOptionsFactory) {
+    this.logger =
+      options.createRabbitOptions()?.extraOptions?.loggerInstance ??
+      new Logger(AMQPConnectionManager.name);
     AMQPConnectionManager.rabbitModuleOptions = {
       ...this.defaultOptions,
       ...options.createRabbitOptions(),

--- a/src/rabbitmq-consumers.ts
+++ b/src/rabbitmq-consumers.ts
@@ -16,7 +16,7 @@ type InspectInput = {
 };
 
 export class RabbitMQConsumer {
-  private logger = new Logger(RabbitMQConsumer.name);
+  private logger: Console | Logger;
 
   private readonly connection: AmqpConnectionManager;
   private readonly options: RabbitMQModuleOptions;
@@ -43,6 +43,10 @@ export class RabbitMQConsumer {
     this.logType =
       (process.env.RABBITMQ_LOG_TYPE as LogType) ??
       this.options.extraOptions.logType;
+
+    this.logger =
+      options?.extraOptions?.loggerInstance ??
+      new Logger(RabbitMQConsumer.name);
   }
 
   public async createConsumer(

--- a/src/rabbitmq-consumers.ts
+++ b/src/rabbitmq-consumers.ts
@@ -41,7 +41,7 @@ export class RabbitMQConsumer {
     this.publishChannel = publishChannelWrapper;
 
     this.logType =
-      (process.env.RABBITMQ_TRAFFIC_TYPE as LogType) ??
+      (process.env.RABBITMQ_LOG_TYPE as LogType) ??
       this.options.extraOptions.logType;
   }
 

--- a/src/rabbitmq-service.ts
+++ b/src/rabbitmq-service.ts
@@ -44,7 +44,6 @@ export class RabbitMQService {
         {
           correlationId: randomUUID(),
           ...options,
-          headers: { "x-delay": 0, ...options?.headers },
         },
       );
     } catch (e) {

--- a/src/rabbitmq-service.ts
+++ b/src/rabbitmq-service.ts
@@ -6,7 +6,9 @@ import { RabbitMQConsumer } from "./rabbitmq-consumers";
 import { ChannelWrapper } from "amqp-connection-manager";
 
 export class RabbitMQService {
-  private logger = new Logger(RabbitMQService.name);
+  private logger: Console | Logger =
+    AMQPConnectionManager.rabbitModuleOptions?.extraOptions?.loggerInstance ??
+    new Logger(RabbitMQService.name);
 
   /**
    * Check status of the main conenection to the broker.

--- a/src/rabbitmq.module.ts
+++ b/src/rabbitmq.module.ts
@@ -13,7 +13,7 @@ export class RabbitMQModule {
   static register(options: RabbitOptions): DynamicModule {
     return {
       module: RabbitMQModule,
-      imports: [...(options?.injects ?? [])],
+      imports: options?.injects ?? [],
       global: true,
       providers: [
         AMQPConnectionManager,

--- a/src/rabbitmq.types.ts
+++ b/src/rabbitmq.types.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common";
 import { IDelayProgression, IRabbitHandler } from "./rabbitmq.interfaces";
 
 export type RabbitMQExchangeTypes = "direct" | "topic" | "fanout" | "headers";
@@ -30,11 +31,12 @@ export type RabbitMQConsumerOptions = {
   exchangeName: string;
 
   /** Routing key between the Queue and the exchange. This acts as a filter so only this routing key will be received by the queue.
+   * The parameter accepts an array of routing keys and each entry will be declared.
    * For exchanges of the type `fanout` this parameter will be ignored
    * This parameter accepts patterns
    *   E.g: webhook.`#` - Routes all messages that contains at least `webhook` in the routing key. (webhooks, webhooks.test)
    *        webhook.\*.test - Routes all messages that contains the described patter (webhook.ABC.test, webhook.123.test) */
-  routingKey: string;
+  routingKey: string | string[];
 
   /** When the consumer throwns an error. The message will be automatically enqueued to a retry queue. Here you declare the strategies for retrying */
   retryStrategy?: {

--- a/src/rabbitmq.types.ts
+++ b/src/rabbitmq.types.ts
@@ -136,6 +136,13 @@ export type RabbitMQModuleOptions = {
     /** Enables the message inspection of different parts of the RabbitMQ
      * this option can be overriden by using the env RABBITMQ_LOG_TYPE */
     logType?: LogType;
+
+    /**
+     * Will use the given logger instead of the default Logger from NestJS. Ensure that the logger follows the
+     * NestJS Logger or Console interfaces to be used
+     *Default: new Logger()
+     */
+    loggerInstance?: Console | Logger;
   };
 };
 

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -114,7 +114,7 @@ describe("AMQPConnectionManager", () => {
 
       const isPublished = await rabbitMqService.publish(
         TestConsumers[0].exchangeName,
-        TestConsumers[0].routingKey,
+        TestConsumers[0].routingKey as string,
         { test: "published" },
       );
 
@@ -180,7 +180,7 @@ describe("AMQPConnectionManager", () => {
 
       await rabbitMqService.publish(
         TestConsumers[0].exchangeName,
-        TestConsumers[0].routingKey,
+        TestConsumers[0].routingKey as string,
         publishedMessage,
       );
 
@@ -222,7 +222,7 @@ describe("AMQPConnectionManager", () => {
 
       await rabbitMqService.publish(
         TestConsumers[1].exchangeName,
-        TestConsumers[1].routingKey,
+        TestConsumers[1].routingKey as string,
         publishedMessage,
       );
 

--- a/test/manual-consumer.spec.ts
+++ b/test/manual-consumer.spec.ts
@@ -70,7 +70,7 @@ describe("AMQPConnectionManager Late Loading", () => {
 
     const isPublished = await rabbitMqService.publish(
       TestConsumers[0].exchangeName,
-      TestConsumers[0].routingKey,
+      TestConsumers[0].routingKey as string,
       { test: "published" },
     );
 


### PR DESCRIPTION
You can now pass an array of routingKeys to the same consumer entry, all keys will be created and binded to the given queue.

Example:
```
          options: {
            queue: 'my_event',
            exchangeName: 'my_exchange',
            routingKey: ['new-event', 'rk1', 'rk2'],
            prefetch: Number(process.env.RABBIT_PREFETCH ?? 10),
            retryStrategy: {
              enabled: true,
              maxAttempts: 10,
              delay: (attempt) => {
                return attempt * 5000;
              },
            },
          },
          messageHandler: this.queueProcessorService.messageHandler.bind(
            this.queueProcessorService,
          ),
```

---

The option `loggerInstance` was added to the `extraOptions` entry. You can pass a custom logger to the library and it will use it instead of the default NestJS logger.