### PR TITLE
Fixed publisher channel not waiting for connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,14 +423,6 @@ You can also use the `extraOptions.loggerInstance` to pass your custom Logger
 as long as it follows the Logger/Console interfaces. The SDK will use the given
 instance to log any messages
 
-### Detach connection from NestJS lifecycle
-
-By passing the flag `extraOptions.connectionType = 'async'` the library will not
-wait for the connection to be done before releasing the `onModuleInit` lifecycle.
-
-This can be useful if your application does not depend on the AMQP connection
-and is used as a backup or something not central, for example.
-
 ## How to build this library locally ?
 
 Just pull the project and run:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bgaldino/nestjs-rabbitmq",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A different way of configuring your RabbitMQ",
   "main": "dist/index.js",
   "author": "Bruno Galdino <brunogaldinoc@gmail.com>",

--- a/src/amqp-connection-manager.ts
+++ b/src/amqp-connection-manager.ts
@@ -166,10 +166,10 @@ export class AMQPConnectionManager
         publishTimeout: 60000,
       });
 
-    await AMQPConnectionManager.publishChannelWrapper.addSetup(
-      async (channel: ConfirmChannel) => {
-        for (const publisher of AMQPConnectionManager.rabbitModuleOptions
-          ?.assertExchanges ?? []) {
+    for (const publisher of AMQPConnectionManager.rabbitModuleOptions
+      ?.assertExchanges ?? []) {
+      await AMQPConnectionManager.publishChannelWrapper.addSetup(
+        async (channel: ConfirmChannel) => {
           const isDelayed = publisher.options?.isDelayed ?? false;
           const type = isDelayed ? "x-delayed-message" : publisher.type;
           const argument = isDelayed
@@ -181,9 +181,9 @@ export class AMQPConnectionManager
             autoDelete: publisher?.options?.autoDelete ?? false,
             ...argument,
           });
-        }
-      },
-    );
+        },
+      );
+    }
   }
 
   private async createConsumers(): Promise<void> {

--- a/src/rabbitmq.types.ts
+++ b/src/rabbitmq.types.ts
@@ -118,12 +118,6 @@ export type RabbitMQModuleOptions = {
   consumerChannels?: Array<RabbitMQConsumerChannel>;
 
   extraOptions?: {
-    /** When **`sync`**, the connection will be made synchronously during the `OnModuleInit` lifecycle
-     * and will only return after the connection is sucessfully made
-     * When **`async`**, the connection is made asynchronously and will release the lifecycle event as fast as possible.
-     * Default: `sync` */
-    connectionType?: "sync" | "async";
-
     /** When **TRUE** the SDK will not initiate the consumers automatically during the _OnModuleInit_
      * To initiate the consumer, you can call it at the end of the `bootstrap()` on your `main.ts` file
      * ```javascript

--- a/test/fixtures/configs/rmq-test-manual-consumer.config.ts
+++ b/test/fixtures/configs/rmq-test-manual-consumer.config.ts
@@ -16,7 +16,6 @@ export class RmqTestManualConsumerConfig implements RabbitOptionsFactory {
       extraOptions: {
         consumerManualLoad: true,
         logType: "none",
-        connectionType: "async",
       },
       assertExchanges: [{ name: "test_direct.exchange", type: "direct" }],
       consumerChannels: [

--- a/test/fixtures/configs/rmq-test.config.ts
+++ b/test/fixtures/configs/rmq-test.config.ts
@@ -49,7 +49,6 @@ export class RmqTestConfig implements RabbitOptionsFactory {
       delayExchangeName: delayExchangeName,
       assertExchanges: TestExchanges,
       extraOptions: {
-        connectionType: "sync",
         logType: "all",
       },
       consumerChannels: [


### PR DESCRIPTION
When you have many entries on the `assertExchanges`, the publisherChannel setup may run after the consumers try to bind to the exchange. When this happens, the connection terminally fails with an NOT_FOUND exception from the underlying amqplib.

In order to solve that, a new promise was created to be resolved only when the publish channel receives the `connect`. The addSetup is called after that.