### PR TITLE
chore: forcing message persistence when retrying a message after throw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bgaldino/nestjs-rabbitmq",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A different way of configuring your RabbitMQ",
   "main": "dist/index.js",
   "author": "Bruno Galdino <brunogaldinoc@gmail.com>",

--- a/src/rabbitmq-consumers.ts
+++ b/src/rabbitmq-consumers.ts
@@ -209,6 +209,8 @@ export class RabbitMQConsumer {
                 retriesCount: retryCount + 1,
                 "x-delay": retryDelay,
               },
+              deliveryMode: 2, //persistent message
+              persistent: true,
             },
           );
         } catch (e) {

--- a/src/rabbitmq-service.ts
+++ b/src/rabbitmq-service.ts
@@ -46,6 +46,8 @@ export class RabbitMQService {
         {
           correlationId: randomUUID(),
           ...options,
+          persistent: true,
+          deliveryMode: 2,
         },
       );
     } catch (e) {


### PR DESCRIPTION
Forcefully setting `delivery_mode: 2` on every publish and retry to ensure messages are not lost when an instance reboot happens.