### PR TITLE
Feat/export mock testing module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: nestjs-rabbitmq
+on:
+  pull_request:
+    branches:
+      - feat/publish-bulk
+jobs:
+  check-application:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,8 @@
 name: nestjs-rabbitmq
 on:
-  [push]
-  # pull_request:
-  #   branches:
-  #     - feat/publish-bulk
+  pull_request:
+    branches:
+      - main
 jobs:
   check-application:
     runs-on: ubuntu-latest
@@ -29,12 +28,12 @@ jobs:
       - name: Install depencencies
         run: pnpm i
 
-      - name: Esperar o RabbitMQ subir
+      - name: Wait for RabbitMQ to go up
         run: |
-          echo "Aguardando RabbitMQ..."
+          echo "Waiting RabbitMQ..."
           for i in {1..10}; do
             nc -z localhost 5672 && echo "RabbitMQ OK" && break
-            echo "Aguardando..."
+            echo "Waiting..."
             sleep 5
           done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,17 @@
 name: nestjs-rabbitmq
+
 on:
   pull_request:
     branches:
       - main
+      - develop
+
 jobs:
   check-application:
     runs-on: ubuntu-latest
     services:
       rabbitmq:
-        image: heidiks/rabbitmq-delayed-message-exchange:latest
+        image: heidiks/rabbitmq-delayed-message-exchange:4.0.2-management
         ports:
           - 5672:5672
           - 15672:15672
@@ -16,29 +19,39 @@ jobs:
           --health-cmd "rabbitmq-diagnostics -q ping"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+
       - name: Install pnpm
         run: npm install -g pnpm
 
-      - name: Install depencencies
-        run: pnpm i
+      - name: Install dependencies
+        run: pnpm install
 
-      - name: Wait for RabbitMQ to go up
+      - name: Wait for RabbitMQ to be healthy
         run: |
-          echo "Waiting RabbitMQ..."
-          for i in {1..10}; do
-            nc -z localhost 5672 && echo "RabbitMQ OK" && break
-            echo "Waiting..."
-            sleep 5
+          echo "Waiting for RabbitMQ to become healthy..."
+          for i in {1..20}; do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' ${{ job.services.rabbitmq.id }})
+            echo "Status: $STATUS"
+            if [ "$STATUS" == "healthy" ]; then
+              echo "RabbitMQ is healthy"
+              exit 0
+            fi
+            sleep 3
           done
+          echo "RabbitMQ did not become healthy in time"
+          exit 1
 
-      - name: Test
+      - name: Run tests
         run: pnpm test
 
       - name: Build
         run: pnpm build
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: nestjs-rabbitmq
 on:
-  pull_request:
-    branches:
-      - feat/publish-bulk
+  [push]
+  # pull_request:
+  #   branches:
+  #     - feat/publish-bulk
 jobs:
   check-application:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rabbitmq:
-        image: heidiks/rabbitmq-delayed-message-exchange:latest
+        image: heidiks/rabbitmq-delayed-message-exchange:4.0.2-management
         ports:
           - 5672:5672
           - 15672:15672

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,39 @@ on:
 jobs:
   check-application:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: heidiks/rabbitmq-delayed-message-exchange:latest
+        ports:
+          - 5672:5672
+          - 15672:15672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm test
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install depencencies
+        run: pnpm i
+
+      - name: Esperar o RabbitMQ subir
+        run: |
+          echo "Aguardando RabbitMQ..."
+          for i in {1..10}; do
+            nc -z localhost 5672 && echo "RabbitMQ OK" && break
+            echo "Aguardando..."
+            sleep 5
+          done
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ dist
 
 *example
 # End of https://www.toptal.com/developers/gitignore/api/node
+#
+#
+# Ignore shell script files
+*.sh

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [The configuration file](#the-configuration-file)
   - [Publishers](#publishers)
     - [Publishing messages](#publishing-messages)
+    - [Publishing messages in bulk](#publishing-messages-in-bulk)
     - [Custom headers](#custom-headers)
   - [Consumers](#consumers)
     - [The messageHandler callback](#the-messagehandler-callback)
@@ -168,10 +169,46 @@ async publishMeTyped() {
   //This will return an error if the object is not properly typed
 }
 ```
-
-The `publish()` method uses [Publish Confirms](https://www.rabbitmq.com/docs/confirms#publisher-confirms)
+The `publish()` and `publishBulk()` methods uses [Publish Confirms](https://www.rabbitmq.com/docs/confirms#publisher-confirms)
 to make sure that the message is delivered to the broker before returning
 the promise.
+
+### Publishing messages in bulk
+```typescript
+import { Injectable } from "@nestjs/common";
+import { RabbitMQService } from "@bgaldino/nestjs-rabbitmq";
+
+@Injectable()
+export class MyService {
+  constructor(private readonly rabbitMQService: RabbitMQService) {}
+}
+
+async publishMe(){
+  const faileds = await this.rabbitMQService.publishBulk('exchange_name', 'routing_key', [{}]);
+}
+
+//or
+
+async publishMeTyped() {
+  const faileds = await this.rabbitMQService.publishBulk<CustomType>('exchange_name', 'routing_key', [{}]);
+  //This will return an error if the object is not properly typed
+}
+```
+
+
+
+The `publishBulk()` method returns only the messages that failed to receive confirmation via Publish Confirms.
+
+The publishBulk() method also provides a batchSize option to control how many messages are sent in parallel. The default value is 100. Use this setting with caution, as setting it too high may lead to excessive memory usage or network saturation.
+
+### Exemple
+```typescript
+
+async publishMe(){
+  const faileds = await this.rabbitMQService.publishBulk('exchange_name', 'routing_key', [{}],{ batchSize: 500 },);
+}
+
+```
 
 ### Custom headers
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: heidiks/rabbitmq-delayed-message-exchange:latest
+    container_name: rabbitmq
+    restart: always
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    mem_limit: 512m
+    cpus: 0.2
+    networks:
+      - default
+
+volumes:
+  rabbitmq_data:
+    driver: local
+
+networks:
+  default:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,11 @@ services:
       - rabbitmq_data:/var/lib/rabbitmq
     mem_limit: 512m
     cpus: 0.2
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       - default
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "test": "NODE_ENV=develop node --expose-gc ./node_modules/jest/bin/jest.js --config ./test/jest.config.json --runInBand --logHeapUsage --coverage",
     "build": "rimraf dist && tsc",
-    "prepublish": "pnpm run build"
+    "prepublish": "pnpm run build",
+    "test:ci": "NODE_ENV=develop node --expose-gc ./node_modules/jest/bin/jest.js --config ./test/jest.config.json"
   },
   "dependencies": {
     "@types/amqplib": "^0.10.6",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   "scripts": {
     "test": "NODE_ENV=develop node --expose-gc ./node_modules/jest/bin/jest.js --config ./test/jest.config.json --runInBand --logHeapUsage --coverage",
     "build": "rimraf dist && tsc",
-    "prepublish": "pnpm run build",
-    "test:ci": "NODE_ENV=develop node --expose-gc ./node_modules/jest/bin/jest.js --config ./test/jest.config.json"
+    "prepublish": "pnpm run build"
   },
   "dependencies": {
     "@types/amqplib": "^0.10.6",
     "amqp-connection-manager": "^4.1.14",
     "amqplib": "^0.10.3",
     "faster-stable-stringify": "^1.0.0",
+    "jest-mock-extended": "3.0.7",
     "reflect-metadata": "^0.2.1",
     "rimraf": "^5.0.5",
     "rxjs": "^7.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       faster-stable-stringify:
         specifier: ^1.0.0
         version: 1.0.0
+      jest-mock-extended:
+        specifier: 3.0.7
+        version: 3.0.7(jest@29.7.0(@types/node@22.2.0))(typescript@5.5.4)
       reflect-metadata:
         specifier: ^0.2.1
         version: 0.2.2
@@ -1170,6 +1173,12 @@ packages:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-mock-extended@3.0.7:
+    resolution: {integrity: sha512-7lsKdLFcW9B9l5NzZ66S/yTQ9k8rFtnwYdCNuRU/81fqDWicNDVhitTSPnrGmNeNm0xyw0JHexEOShrIKRCIRQ==}
+    peerDependencies:
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1668,6 +1677,14 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-essentials@10.0.4:
+    resolution: {integrity: sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ts-jest@29.2.4:
     resolution: {integrity: sha512-3d6tgDyhCI29HlpwIq87sNuI+3Q6GLTTCeYRHCs7vDz+/3GCMwEtV9jezLyl4ZtnBgx00I7hm8PCP8cTksMGrw==}
@@ -3188,6 +3205,12 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock-extended@3.0.7(jest@29.7.0(@types/node@22.2.0))(typescript@5.5.4):
+    dependencies:
+      jest: 29.7.0(@types/node@22.2.0)
+      ts-essentials: 10.0.4(typescript@5.5.4)
+      typescript: 5.5.4
+
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -3705,6 +3728,10 @@ snapshots:
 
   ts-api-utils@1.3.0(typescript@5.5.4):
     dependencies:
+      typescript: 5.5.4
+
+  ts-essentials@10.0.4(typescript@5.5.4):
+    optionalDependencies:
       typescript: 5.5.4
 
   ts-jest@29.2.4(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@22.2.0))(typescript@5.5.4):

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,5 @@ export {
   RabbitMQConsumerOptions,
   RabbitMQConsumerChannel,
 } from "./rabbitmq.types";
+
+export * from "./test.mocked.module";

--- a/src/rabbitmq-service.ts
+++ b/src/rabbitmq-service.ts
@@ -100,9 +100,9 @@ export class RabbitMQService implements OnApplicationBootstrap {
     exchangeName: string,
     routingKey: string,
     messages: T[],
-    options?: PublishOptions,
-    batchSize: number = 100,
+    options?: PublishOptions & { batchSize?: number }
   ): Promise<T[]> {
+    const batchSize = options?.batchSize ?? 100;
     const faileds: T[] = [];
     for (let i = 0; i < messages.length; i += batchSize) {
       const chunk = messages.slice(i, i + batchSize);

--- a/src/rabbitmq-service.ts
+++ b/src/rabbitmq-service.ts
@@ -50,7 +50,7 @@ export class RabbitMQService implements OnApplicationBootstrap {
   ): Promise<boolean> {
     let hasErrors = null;
     const start = process.hrtime.bigint();
-    const defaultHeaders = {
+    const defaultOptions = {
       correlationId: randomUUID(),
       headers: {
         "x-application-headers": {
@@ -62,13 +62,13 @@ export class RabbitMQService implements OnApplicationBootstrap {
       persistent: true,
       deliveryMode: 2,
     };
-
+    const mergedOptions = merge(defaultOptions, options)
     try {
       await AMQPConnectionManager.publishChannelWrapper.publish(
         exchangeName,
         routingKey,
         stringify(message),
-        merge(defaultHeaders, options),
+        mergedOptions,
       );
     } catch (e) {
       hasErrors = e;
@@ -78,7 +78,7 @@ export class RabbitMQService implements OnApplicationBootstrap {
         routingKey,
         message,
         process.hrtime.bigint() - start,
-        options,
+        mergedOptions,
         hasErrors,
       );
     }

--- a/src/test.mocked.module.ts
+++ b/src/test.mocked.module.ts
@@ -1,0 +1,31 @@
+import { DynamicModule, Module, Type } from "@nestjs/common";
+import { mock } from "jest-mock-extended";
+import { RabbitOptionsFactory } from "./rabbitmq.interfaces";
+import { AMQPConnectionManager } from "./amqp-connection-manager";
+import { RabbitMQService } from "./rabbitmq-service";
+
+export type RabbitOptions = {
+  useClass: Type<RabbitOptionsFactory>;
+  injects?: any[];
+};
+
+const mockAmqpConnectionManager = mock(AMQPConnectionManager);
+@Module({})
+export class RabbitMQMockedTestModule {
+  static register(options: RabbitOptions): DynamicModule {
+    return {
+      module: RabbitMQMockedTestModule,
+      imports: options?.injects ?? [],
+      global: true,
+      providers: [
+        mockAmqpConnectionManager,
+        {
+          provide: "RABBIT_OPTIONS",
+          useClass: options.useClass,
+        },
+        RabbitMQService,
+      ],
+      exports: [RabbitMQService],
+    };
+  }
+}

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -27,15 +27,9 @@ describe("AMQPConnectionManager", () => {
   let amqpManager: AMQPConnectionManager;
   let testService: RmqTestService;
   let moduleRef: TestingModule;
-  let globalConsumerCallbackSpy: any;
   let globalConsumerThrowSpy: any;
 
   beforeAll(async () => {
-    globalConsumerCallbackSpy = jest.spyOn(
-      RmqTestService.prototype,
-      "messageHandler",
-    );
-
     globalConsumerThrowSpy = jest.spyOn(
       RmqTestService.prototype,
       "throwHandler",
@@ -236,10 +230,7 @@ describe("AMQPConnectionManager", () => {
     });
 
     it("should publish an array of messages and return 1 failed message", async () => {
-      const rabbitPublish = jest.spyOn(
-        AMQPConnectionManager.publishChannelWrapper,
-        "publish",
-      );
+      jest.spyOn(AMQPConnectionManager.publishChannelWrapper, "publish");
       jest
         .spyOn(rabbitMqService, "publish")
         .mockResolvedValueOnce(false)

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -73,10 +73,10 @@ describe("AMQPConnectionManager", () => {
     await moduleRef.close();
   });
 
-  afterEach(()=>{
+  afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
-  })
+  });
 
   it("should return a truthy connection health", async () => {
     expect(testService.rabbitService.checkHealth()).toBeTruthy();
@@ -187,7 +187,12 @@ describe("AMQPConnectionManager", () => {
       const isPublished = await rabbitMqService.publishBulk(
         TestConsumers[0].exchangeName,
         TestConsumers[0].routingKey as string,
-        [{ test: "published" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        [
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+        ],
         { correlationId: "123" },
       );
 
@@ -236,7 +241,9 @@ describe("AMQPConnectionManager", () => {
         "publish",
       );
       jest
-      .spyOn(rabbitMqService,"publish").mockResolvedValueOnce(false).mockResolvedValue(true)
+        .spyOn(rabbitMqService, "publish")
+        .mockResolvedValueOnce(false)
+        .mockResolvedValue(true);
       jest
         .spyOn(RmqTestService.prototype, "messageHandler")
         .mockImplementation(async () => {});
@@ -244,23 +251,26 @@ describe("AMQPConnectionManager", () => {
       const publisheds = await rabbitMqService.publishBulk<any>(
         TestConsumers[0].exchangeName,
         TestConsumers[0].routingKey as string,
-        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        [
+          { test: "failed" },
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+        ],
         { correlationId: "123" },
       );
 
-      expect(publisheds.length).toBe(1)
-      expect(publisheds[0].test).toBe("failed")
+      expect(publisheds.length).toBe(1);
+      expect(publisheds[0].test).toBe("failed");
     });
 
     it("should return messages that failed to publish if the connection to rabbitmq is lost", async () => {
-      const rabbitPublish = jest.spyOn(
-        AMQPConnectionManager.publishChannelWrapper,
-        "publish",
-      );
+      jest.spyOn(AMQPConnectionManager.publishChannelWrapper, "publish");
+      jest.spyOn(rabbitMqService, "publish").mockResolvedValue(true);
       jest
-      .spyOn(rabbitMqService,"publish").mockResolvedValue(true)
-      jest
-      .spyOn(rabbitMqService,"checkHealth").mockReturnValueOnce(1).mockReturnValue(0)
+        .spyOn(rabbitMqService, "checkHealth")
+        .mockReturnValueOnce(1)
+        .mockReturnValue(0);
       jest
         .spyOn(RmqTestService.prototype, "messageHandler")
         .mockImplementation(async () => {});
@@ -268,12 +278,16 @@ describe("AMQPConnectionManager", () => {
       const publisheds = await rabbitMqService.publishBulk<any>(
         TestConsumers[0].exchangeName,
         TestConsumers[0].routingKey as string,
-        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
-        { correlationId: "123" },
-        1
+        [
+          { test: "failed" },
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+        ],
+        { correlationId: "123", batchSize: 1 },
       );
 
-      expect(publisheds.length).toBe(2)
+      expect(publisheds.length).toBe(2);
     });
   });
 

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -73,6 +73,11 @@ describe("AMQPConnectionManager", () => {
     await moduleRef.close();
   });
 
+  afterEach(()=>{
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  })
+
   it("should return a truthy connection health", async () => {
     expect(testService.rabbitService.checkHealth()).toBeTruthy();
   });
@@ -162,6 +167,113 @@ describe("AMQPConnectionManager", () => {
           },
         }),
       );
+    });
+
+    it("should publish a array of messages to a declared exchange and log it with custom headers", async () => {
+      jest.clearAllMocks();
+
+      const spy = jest.spyOn(RabbitMQService.prototype, "publish");
+      const rabbitPublish = jest.spyOn(
+        AMQPConnectionManager.publishChannelWrapper,
+        "publish",
+      );
+
+      const loggerSpy = jest.spyOn(Logger.prototype, "log");
+
+      jest
+        .spyOn(RmqTestService.prototype, "messageHandler")
+        .mockImplementation(async () => {});
+
+      const isPublished = await rabbitMqService.publishBulk(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].routingKey as string,
+        [{ test: "published" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        { correlationId: "123" },
+      );
+
+      expect(spy).toHaveBeenCalled();
+
+      expect(rabbitPublish).toHaveBeenCalledWith(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].queue,
+        JSON.stringify({ test: "published" }),
+        {
+          correlationId: "123",
+          deliveryMode: 2,
+          persistent: true,
+          headers: {
+            "x-application-headers": {
+              "original-exchange": TestConsumers[0].exchangeName,
+              "original-routing-key": TestConsumers[0].routingKey,
+              "published-at": expect.any(String),
+            },
+          },
+        },
+      );
+
+      expect(isPublished).toBeTruthy();
+
+      expect(loggerSpy.mock.lastCall?.[0]).toMatchObject(
+        expect.objectContaining({
+          logLevel: "log",
+          title: `[AMQP] [PUBLISH] [${TestConsumers[0].exchangeName}] [${TestConsumers[0].routingKey}]`,
+          binding: {
+            routingKey: TestConsumers[0].routingKey,
+            exchange: TestConsumers[0].exchangeName,
+          },
+          correlationId: "123",
+          publishedMessage: {
+            content: { test: "published" },
+            properties: { correlationId: "123" },
+          },
+        }),
+      );
+    });
+
+    it("should publish an array of messages and return 1 failed message", async () => {
+      const rabbitPublish = jest.spyOn(
+        AMQPConnectionManager.publishChannelWrapper,
+        "publish",
+      );
+      jest
+      .spyOn(rabbitMqService,"publish").mockResolvedValueOnce(false).mockResolvedValue(true)
+      jest
+        .spyOn(RmqTestService.prototype, "messageHandler")
+        .mockImplementation(async () => {});
+
+      const publisheds = await rabbitMqService.publishBulk<any>(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].routingKey as string,
+        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        { correlationId: "123" },
+      );
+
+      expect(publisheds.length).toBe(1)
+      expect(publisheds[0].test).toBe("failed")
+    });
+
+    it("should return messages that failed to publish if the connection to rabbitmq is lost", async () => {
+      const rabbitPublish = jest.spyOn(
+        AMQPConnectionManager.publishChannelWrapper,
+        "publish",
+      );
+      jest
+      .spyOn(rabbitMqService,"publish").mockResolvedValue(true)
+      jest
+      .spyOn(rabbitMqService,"checkHealth").mockReturnValueOnce(1).mockReturnValue(0)
+      jest
+        .spyOn(RmqTestService.prototype, "messageHandler")
+        .mockImplementation(async () => {});
+
+      const publisheds = await rabbitMqService.publishBulk<any>(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].routingKey as string,
+        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        { correlationId: "123" },
+        1
+      );
+
+      expect(publisheds.length).toBe(2)
     });
   });
 

--- a/test/crash-connection.spec.ts
+++ b/test/crash-connection.spec.ts
@@ -58,7 +58,7 @@ describe("CrashedConnection", () => {
     expect(logSpy).toHaveBeenCalled();
 
     expect(logSpy.mock.lastCall?.[0]).toMatchObject(
-      expect.objectContaining({
+      {
         logLevel: "error",
         title: `[AMQP] [PUBLISH] [not_exists.exchange] [not_exists.key]`,
         binding: {
@@ -69,7 +69,7 @@ describe("CrashedConnection", () => {
           content: { test: "error" },
         },
         error: expect.objectContaining({ message: "channel closed" }),
-      }),
+      },
     );
   });
 });

--- a/test/fixtures/configs/rmq-test-manual-consumer.config.ts
+++ b/test/fixtures/configs/rmq-test-manual-consumer.config.ts
@@ -11,7 +11,7 @@ export class RmqTestManualConsumerConfig implements RabbitOptionsFactory {
 
   createRabbitOptions(): RabbitMQModuleOptions {
     return {
-      connectionString: "amqp://localhost:5672",
+      connectionString: "amqp://guest:guest@localhost:5672",
       delayExchangeName: delayExchangeName,
       extraOptions: {
         consumerManualLoad: true,

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -9,5 +9,6 @@
   "coverageDirectory": "./coverage",
   "coverageReporters": ["clover", "json", "lcov", "text"],
   "collectCoverageFrom": ["src/**/*.ts"],
-  "globalTeardown": "<rootDir>/test/global-teardown.ts"
+  "globalTeardown": "<rootDir>/test/global-teardown.ts",
+  "timeout": 10000
 }


### PR DESCRIPTION
# 🧪 RabbitMQMockedTestModule

A testing utility module that allows consumers of this library to **mock RabbitMQ interactions** easily, enabling unit or integration testing without the need for a live RabbitMQ server.

## ✅ Purpose

`RabbitMQMockedTestModule` was created to help developers test components that rely on RabbitMQ **without actually connecting to a real broker**. It simulates publishing, consuming, and acknowledging messages, and can be extended to fit various test scenarios.

## 📦 Export

This module is now exported as part of the library and can be imported directly:

```ts
import { RabbitMQMockedTestModule } from 'your-library';